### PR TITLE
Greatly speed up build times.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,13 @@ jobs:
       uses: actions/setup-java@v1.3.0
       with:
         java-version: ${{ matrix.java }}
+
+    - uses: actions/cache@v1.1.2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-maven-
+
     - name: Build YAPFA
       run: |
         git submodule init
@@ -26,7 +33,8 @@ jobs:
         yapfaDir=`pwd`
         ./patchPaper.sh
         cd Tuinity
-        ./tuinity jar
+        mvn -N install
+        ./tuinity patch
         cd $yapfaDir
         ./yapfa patch
         ./yapfa build


### PR DESCRIPTION
This should bring GitHub build times down to ~4mins by caching dependencies and not unnecessarily building Tuinity.