### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Report a bug
+title: "[Bug]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Server Setup**
+Server Specifications:
+
+Plugins used:
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Issue templates allow people to press a button while creating a template and have important information that they need to fill out already laid out for them which will make less of a headache for someone trying to resolve the issue.

I have created a **Bug Report** issue template. Let me know if you would like me to make more.