### PR TITLE
Fix bork hoppers & Pathfinder timings

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -25,6 +25,7 @@ This is an overview over all patches that are currently used.
 | server |  Add option to disable saving projectiles to disk      | William Blake Galbreath |  |
 | server |  Add permission for F3+N debug      | William Blake Galbreath |  |
 | server |  Add timings for Behavior      | Phoenix616 |  |
+| server |  Add timings for Pathfinder      | MrIvanPlays |  |
 | server |  Akarin Updated Save json list async      | tsao chi |  |
 | server |  Allow anvil colors      | William Blake Galbreath |  |
 | api |  Allow inventory resizing      | William Blake Galbreath |  |

--- a/patches/server/0021-Optimize-Hopper-logic.patch
+++ b/patches/server/0021-Optimize-Hopper-logic.patch
@@ -35,7 +35,7 @@ index a29294fbc7cd6fcfff0df9eadd11de3bd7f1405e..2f66740de68667e5c0054a0bc7990256
  
      private void a(World world, BlockPosition blockposition, IBlockData iblockdata) {
 diff --git a/src/main/java/net/minecraft/server/TileEntityHopper.java b/src/main/java/net/minecraft/server/TileEntityHopper.java
-index 95bede605c6401af10f18b641cd12c9d8ec2f207..b4ec6fb407f86bd03d003d9b555df0c58cd6ced5 100644
+index 95bede605c6401af10f18b641cd12c9d8ec2f207..7c3124fc567c64dce5939b449036ba99981959cb 100644
 --- a/src/main/java/net/minecraft/server/TileEntityHopper.java
 +++ b/src/main/java/net/minecraft/server/TileEntityHopper.java
 @@ -661,14 +661,47 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
@@ -53,7 +53,7 @@ index 95bede605c6401af10f18b641cd12c9d8ec2f207..b4ec6fb407f86bd03d003d9b555df0c5
 +        // Yatopia start - replace logic
 +        //return b(this.getWorld(), this.position.shift(enumdirection));
 +        IInventory tmp = b(this.getWorld(), this.position.shift(enumdirection), cachedPushAir);
-+        if (tmp != null && !(tmp instanceof IWorldInventory) && !(tmp instanceof Entity)) {
++        if (tmp != null && !(tmp instanceof Entity)) {
 +            this.cachedPush = tmp;
 +        } else {
 +            cachedPushAir = true;

--- a/patches/server/0033-Add-timings-for-Pathfinder.patch
+++ b/patches/server/0033-Add-timings-for-Pathfinder.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MrIvanPlays <ivan@mrivanplays.com>
+Date: Sun, 16 Aug 2020 13:45:32 +0300
+Subject: [PATCH] Add timings for Pathfinder
+
+
+diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
+index 85b25eace786fa0d7694afa405f9d2bdf4937b6e..2dca961498651b1c06ee61d33507055706afb63e 100644
+--- a/src/main/java/co/aikar/timings/MinecraftTimings.java
++++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
+@@ -54,6 +54,8 @@ public final class MinecraftTimings {
+         return Timings.ofSafe(taskName);
+     }
+ 
++    public static Timing getPathfinderTiming(String mobName) { return Timings.ofSafe("Pathfinder - " + mobName); } // Yatopia
++
+     /**
+      * Gets a timer associated with a plugins tasks.
+      * @param bukkitTask
+diff --git a/src/main/java/net/minecraft/server/NavigationAbstract.java b/src/main/java/net/minecraft/server/NavigationAbstract.java
+index ed37caf036ef9ae4c39622caf9b582678fecdccf..19753de35a3fef41fedd37eaab9f3ad2d5d91308 100644
+--- a/src/main/java/net/minecraft/server/NavigationAbstract.java
++++ b/src/main/java/net/minecraft/server/NavigationAbstract.java
+@@ -28,6 +28,7 @@ public abstract class NavigationAbstract {
+     private int q;
+     private float r;
+     private final Pathfinder s; public Pathfinder getPathfinder() { return this.s; } // Paper - OBFHELPER
++    private co.aikar.timings.Timing timing; // Yatopia
+ 
+     // Tuinity start
+     public boolean isViableForPathRecalculationChecking() {
+@@ -46,6 +47,7 @@ public abstract class NavigationAbstract {
+         int i = MathHelper.floor(entityinsentient.b(GenericAttributes.FOLLOW_RANGE) * 16.0D);
+ 
+         this.s = this.a(i);
++        timing = co.aikar.timings.MinecraftTimings.getPathfinderTiming(entityinsentient.getClass().getSimpleName()); // Yatopia
+     }
+ 
+     public void g() {
+@@ -229,6 +231,10 @@ public abstract class NavigationAbstract {
+     }
+ 
+     public void c() {
++        // Yatopia start
++        timing.startTiming();
++        try {
++        // Yatopia end
+         ++this.e;
+         if (this.m) {
+             this.j();
+@@ -256,6 +262,11 @@ public abstract class NavigationAbstract {
+                 this.a.getControllerMove().a(vec3d.x, this.b.getType(blockposition.down()).isAir() ? vec3d.y : PathfinderNormal.a((IBlockAccess) this.b, blockposition), vec3d.z, this.d);
+             }
+         }
++        // Yatopia start
++        } finally {
++            timing.stopTiming();
++        }
++        // Yatopia end
+     }
+ 
+     protected void l() {


### PR DESCRIPTION
For some reason it was checking if the inventory is NOT an IWorldInventory, but IWorldInventory is implemented by furnaces, shulkers and
brewing stands. This commit is fixing that which will also get ported in 1.16.1

Also added Pathfinder timings in order to see if we need to improve pathfinding.