### PR TITLE
Use Executor.execute()

### DIFF
--- a/patches/server/0010-Player-saving-async-FileIO.patch
+++ b/patches/server/0010-Player-saving-async-FileIO.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Player-saving-async-FileIO
 
 
 diff --git a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
-index cf539c98073b475eb5b769c8cc11d48a7e6d58f1..b19c702bae3e750bee13c8b1b3eaa62f0d3ba1ae 100644
+index cf539c98073b475eb5b769c8cc11d48a7e6d58f1..20b97d1e68132a9f1b62dece5c26da80e67347b7 100644
 --- a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
 +++ b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
 @@ -50,6 +50,7 @@ public class AdvancementDataPlayer {
@@ -21,7 +21,7 @@ index cf539c98073b475eb5b769c8cc11d48a7e6d58f1..b19c702bae3e750bee13c8b1b3eaa62f
          jsonelement.getAsJsonObject().addProperty("DataVersion", SharedConstants.getGameVersion().getWorldVersion());
  
 +        // Yatopia start - replace whole logic
-+        saveThread.submit(() -> {
++        saveThread.execute(() -> {
 +            try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(f), Charsets.UTF_8.newEncoder())) {
 +                AdvancementDataPlayer.b.toJson(jsonelement, writer);
 +            } catch (Throwable e) {
@@ -126,7 +126,7 @@ index 2a15972c0a48153fba481b08351642ed36a9da12..75953420936f1c6e8de221c1331df4d6
              serverstatisticmanager = new ServerStatisticManager(this.server, file1);
              // this.o.put(uuid, serverstatisticmanager); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/server/ServerStatisticManager.java b/src/main/java/net/minecraft/server/ServerStatisticManager.java
-index 3c3b87e37cbf69c223da007e8b7eb646ec83691e..e2d12750bce9cb5ef087412b03809632a678bc04 100644
+index 3c3b87e37cbf69c223da007e8b7eb646ec83691e..ef20b3e43eb9598e79ee3ded40f50ae0cc100872 100644
 --- a/src/main/java/net/minecraft/server/ServerStatisticManager.java
 +++ b/src/main/java/net/minecraft/server/ServerStatisticManager.java
 @@ -30,6 +30,7 @@ public class ServerStatisticManager extends StatisticManager {
@@ -141,7 +141,7 @@ index 3c3b87e37cbf69c223da007e8b7eb646ec83691e..e2d12750bce9cb5ef087412b03809632
              this.a.put( wrapper, entry.getValue().intValue() );
          }
          // Spigot end
-+        saveThread.submit(() -> { // Yatopia
++        saveThread.execute(() -> { // Yatopia
          if (file.isFile()) {
              try {
                  this.a(minecraftserver.getDataFixer(), org.apache.commons.io.FileUtils.readFileToString(file));
@@ -157,7 +157,7 @@ index 3c3b87e37cbf69c223da007e8b7eb646ec83691e..e2d12750bce9cb5ef087412b03809632
          if ( org.spigotmc.SpigotConfig.disableStatSaving ) return; // Spigot
 +        // Yatopia start
 +        String str = this.b();
-+        saveThread.submit(() -> {
++        saveThread.execute(() -> {
          try {
 -            org.apache.commons.io.FileUtils.writeStringToFile(this.d, this.b());
 +            org.apache.commons.io.FileUtils.writeStringToFile(this.d, str);
@@ -179,7 +179,7 @@ index 3c3b87e37cbf69c223da007e8b7eb646ec83691e..e2d12750bce9cb5ef087412b03809632
                                                  ServerStatisticManager.LOGGER.warn("Invalid statistic in {}: Don't know what {} is", this.d, s2);
                                              });
 diff --git a/src/main/java/net/minecraft/server/WorldNBTStorage.java b/src/main/java/net/minecraft/server/WorldNBTStorage.java
-index a959672f5857b987001252c3fd7ace9e83e07c9b..bcae104ac104d6dcdf8653f291b24601247b5a55 100644
+index a959672f5857b987001252c3fd7ace9e83e07c9b..d8969f7f5244548452e5d12325e6fa735ecd3a00 100644
 --- a/src/main/java/net/minecraft/server/WorldNBTStorage.java
 +++ b/src/main/java/net/minecraft/server/WorldNBTStorage.java
 @@ -17,6 +17,7 @@ public class WorldNBTStorage {
@@ -195,7 +195,7 @@ index a959672f5857b987001252c3fd7ace9e83e07c9b..bcae104ac104d6dcdf8653f291b24601
      public void save(EntityHuman entityhuman) {
          if(!com.destroystokyo.paper.PaperConfig.savePlayerData) return; // Paper - Make player data saving configurable
 +        entityhuman.takeSnapshot(); // Yatopia
-+        saveThread.submit(() -> { // Yatopia
++        saveThread.execute(() -> { // Yatopia
          try {
              NBTTagCompound nbttagcompound = entityhuman.save(new NBTTagCompound());
              File file = File.createTempFile(entityhuman.getUniqueIDString() + "-", ".dat", this.playerDir);


### PR DESCRIPTION
As we can see from the [JDK Source Code](http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/AbstractExecutorService.java#l109), `.execute()` is faster than `.submit()`.