### PR TITLE
Fix for recursive awaitTasks call

### DIFF
--- a/patches/server/0064-Improve-task-performance.patch
+++ b/patches/server/0064-Improve-task-performance.patch
@@ -9,7 +9,7 @@ consumption of addTask(R)V
 Co-authored-by: Mykyta Komarn <nkomarn@hotmail.com>
 
 diff --git a/src/main/java/net/minecraft/server/IAsyncTaskHandler.java b/src/main/java/net/minecraft/server/IAsyncTaskHandler.java
-index 5df6be7e8d9b1295ed0700b3be90c3778fc7d77c..5c194a88dc35354079e418853e029004b1fbbe41 100644
+index 5df6be7e8d9b1295ed0700b3be90c3778fc7d77c..cbc03b8bc34e244c08a85bfd681707a49d1046f9 100644
 --- a/src/main/java/net/minecraft/server/IAsyncTaskHandler.java
 +++ b/src/main/java/net/minecraft/server/IAsyncTaskHandler.java
 @@ -13,9 +13,11 @@ public abstract class IAsyncTaskHandler<R extends Runnable> implements Mailbox<R
@@ -34,7 +34,7 @@ index 5df6be7e8d9b1295ed0700b3be90c3778fc7d77c..5c194a88dc35354079e418853e029004
      }
  
      public void execute(Runnable runnable) {
-@@ -99,14 +101,15 @@ public abstract class IAsyncTaskHandler<R extends Runnable> implements Mailbox<R
+@@ -99,14 +101,18 @@ public abstract class IAsyncTaskHandler<R extends Runnable> implements Mailbox<R
      }
  
      protected boolean executeNext() {
@@ -49,12 +49,15 @@ index 5df6be7e8d9b1295ed0700b3be90c3778fc7d77c..5c194a88dc35354079e418853e029004
              return false;
          } else {
 -            this.executeTask(this.d.remove()); // Paper - decompile fix
-+            this.executeTask(next); // Paper - decompile fix // Yatopia - Improve task performance
-+            next = null; // Yatopia - Improve task performance
++            // Yatopia start - Improve task performance
++            R r = next;
++            next = null;
++            this.executeTask(r); // Paper - decompile fix
++            // Yatopia end
              return true;
          }
      }
-@@ -127,8 +130,16 @@ public abstract class IAsyncTaskHandler<R extends Runnable> implements Mailbox<R
+@@ -127,8 +133,16 @@ public abstract class IAsyncTaskHandler<R extends Runnable> implements Mailbox<R
      }
  
      protected void bl() {


### PR DESCRIPTION
A small probable bug which was not found in my previous pr.  
This PR prevents recursive awaitTasks calls from executing the same task again. 