### PR TITLE
Remove TIC-TACS from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Yatopia combines the best patches from many Paper forks and optimization mods, a
 * [Lithium](https://github.com/jellysquid3/lithium-fabric)
 * [Origami](https://github.com/Minebench/Origami)
 * [Purpur](https://github.com/pl3xgaming/Purpur)
-* [Tic-TACS](https://github.com/gegy1000/tic-tacs/)
 
 
 ## Try it out 


### PR DESCRIPTION
I believe the tic-tacs patches were removed. So this shouldn't be in the README.md