### PR TITLE
Make Paper clickable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </div>
 
 ## So what is Yatopia?
-Yatopia combines the best patches from many Paper forks and optimization mods, as well as many unique optimizations. We borrow some of our patches from the following repos:
+Yatopia combines the best patches from many [Paper](https://github.com/PaperMC/Paper) forks and optimization mods, as well as many unique optimizations. We borrow some of our patches from the following repos:
 
 * [Akarin](https://github.com/Akarin-project/Akarin)
 * [EMC](https://github.com/starlis/empirecraft)


### PR DESCRIPTION
I have Yatopia's repository in my bookmarks, and it's really nice to have the ability to access Paper & its forks from one place.