### PR TITLE
Update Netty version

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -10,16 +10,16 @@ This is an overview over all patches that are currently used.
 | ----- | ------------- |:-------------:| -----:|
 | server |  Add 5 second tps average in /tps      | William Blake Galbreath |  |
 | api |  Add ChatColor.getById      | Aikar |  |
-| api |  Add GameProfileLookupEvent      | tr7zw |  |
 | server |  Add GameProfileLookupEvent      | tr7zw |  |
+| api |  Add GameProfileLookupEvent      | tr7zw |  |
 | server |  Add IntelliJ IDEA runnable      | Bud Gidiere |  |
 | server |  Add JsonList save timings      | Ivan Pekov |  |
-| api |  Add NBT API as a first-class lib      | tr7zw |  |
 | server |  Add NBT API as a first-class lib      | tr7zw |  |
+| api |  Add NBT API as a first-class lib      | tr7zw |  |
 | server |  Add a special case for floodgate and offline uuids      | Ivan Pekov |  |
 | server |  Add component util      | William Blake Galbreath |  |
-| api |  Add last tick time API      | Ivan Pekov | tr7zw |
 | server |  Add last tick time API      | Ivan Pekov | tr7zw |
+| api |  Add last tick time API      | Ivan Pekov | tr7zw |
 | server |  Add no-tick block list      | William Blake Galbreath |  |
 | server |  Add nspt command      | Ivan Pekov |  |
 | server |  Add option to disable dolphin treasure searching      | William Blake Galbreath |  |
@@ -85,8 +85,8 @@ This is an overview over all patches that are currently used.
 | server |  MC-147659 - Fix non black cats spawning in swamp huts      | William Blake Galbreath |  |
 | server |  MC-168772 Fix - Add turtle egg block options      | William Blake Galbreath |  |
 | server |  Make lava flow speed configurable      | William Blake Galbreath |  |
-| api |  Modify POM      | YatopiaMC |  |
 | server |  Modify POM      | YatopiaMC |  |
+| api |  Modify POM      | YatopiaMC |  |
 | server |  Modify default configs      | tr7zw |  |
 | server |  Nuke streams off BlockPosition      | Ivan Pekov |  |
 | server |  Nuke streams off SectionPosition      | Ivan Pekov |  |
@@ -107,10 +107,10 @@ This is an overview over all patches that are currently used.
 | server |  PaperPR - Fix username connecting with no texture being      | Camotoy |  |
 | server |  Per entity (type) collision settings      | MrIvanPlays | tr7zw |
 | server |  Persistent TileEntity Lore and DisplayName      | jmp |  |
-| api |  PlayerAttackEntityEvent      | Ivan Pekov |  |
 | server |  PlayerAttackEntityEvent      | Ivan Pekov |  |
-| api |  ProxyForwardDataEvent      | Ivan Pekov |  |
+| api |  PlayerAttackEntityEvent      | Ivan Pekov |  |
 | server |  ProxyForwardDataEvent      | Ivan Pekov |  |
+| api |  ProxyForwardDataEvent      | Ivan Pekov |  |
 | server |  Purpur config files      | William Blake Galbreath |  |
 | server |  Redirect Configs      | tr7zw |  |
 | server |  Reduce projectile chunk loading      | Paul Sauve |  |

--- a/patches/server/0002-Modify-POM.patch
+++ b/patches/server/0002-Modify-POM.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Modify POM
 
 
 diff --git a/pom.xml b/pom.xml
-index e83e4241a56fe131a75fe21cc1518992c089da2c..4fb3f3183ba51e971c98d6104b9100cddc840c92 100644
+index e83e4241a56fe131a75fe21cc1518992c089da2c..b10ec0444fd9fd05bac53071727334431e4e5e54 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -1,11 +1,11 @@
@@ -53,6 +53,15 @@ index e83e4241a56fe131a75fe21cc1518992c089da2c..4fb3f3183ba51e971c98d6104b9100cd
              <version>${project.version}</version>
              <scope>compile</scope>
          </dependency>
+@@ -42,7 +51,7 @@
+         <dependency>
+             <groupId>io.netty</groupId>
+             <artifactId>netty-all</artifactId>
+-            <version>4.1.50.Final</version>
++            <version>4.1.58.Final</version>
+         </dependency>
+         <!-- Tuinity end - fix compile issue (cannot see new api) by moving netty include BEFORE server jar -->
+         <dependency>
 @@ -159,6 +168,12 @@
              <version>1.1.0-SNAPSHOT</version>
              <scope>compile</scope>

--- a/patches/server/0004-Utilities.patch
+++ b/patches/server/0004-Utilities.patch
@@ -9,7 +9,7 @@ Co-authored-by: Mykyta Komarnytskyy <nkomarn@hotmail.com>
 Co-authored-by: Ivan Pekov <ivan@mrivanplays.com>
 
 diff --git a/pom.xml b/pom.xml
-index 4fb3f3183ba51e971c98d6104b9100cddc840c92..bf5f5ceba13f6b6eff3b58f27b28e9d8500a58ef 100644
+index b10ec0444fd9fd05bac53071727334431e4e5e54..ae24022cd8af15a6efc376b1fdb1813afd85163e 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -174,6 +174,12 @@

--- a/patches/server/0010-Add-NBT-API-as-a-first-class-lib.patch
+++ b/patches/server/0010-Add-NBT-API-as-a-first-class-lib.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add NBT API as a first-class lib
 
 
 diff --git a/pom.xml b/pom.xml
-index bf5f5ceba13f6b6eff3b58f27b28e9d8500a58ef..cd681eb181571543b63108f33d1d3f129c035e84 100644
+index ae24022cd8af15a6efc376b1fdb1813afd85163e..04b51c3b600e5b33d02adf51b58b7dc19d051910 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -356,6 +356,10 @@


### PR DESCRIPTION
This PR bumps the netty version from `4.1.50.Final` to `4.1.58.Final`. This was just something that caught my eye and I thought it might be worth PRing.