### PR TITLE
[CI-SKIP] fix typo in MCDevImports.kt

### DIFF
--- a/buildSrc/src/main/kotlin/MCDevImports.kt
+++ b/buildSrc/src/main/kotlin/MCDevImports.kt
@@ -1,7 +1,7 @@
 /**
  * This is the set of extra NMS files which will be imported as part of the patch process
  *
- * See `./Paper/work/Minecraft/$MCVER/classes/net/minecraft/server` for a list of possible files
+ * See `./Paper/work/Minecraft/$MCVER/spigot/net/minecraft/server` for a list of possible files
  *
  * The `.java` extension is always assumed and should be excluded
  *

--- a/buildSrc/src/main/kotlin/MCDevImports.kt
+++ b/buildSrc/src/main/kotlin/MCDevImports.kt
@@ -1,7 +1,7 @@
 /**
  * This is the set of extra NMS files which will be imported as part of the patch process
  *
- * See `./Paper/work/Minecraft/$MCVER/net/minecraft/server` for a list of possible files
+ * See `./Paper/work/Minecraft/$MCVER/classes/net/minecraft/server` for a list of possible files
  *
  * The `.java` extension is always assumed and should be excluded
  *


### PR DESCRIPTION
fixes:
![image](https://user-images.githubusercontent.com/11786225/105614452-93707e00-5d97-11eb-8dc2-2645f5f64b52.png)
Edit: it should actually be `/spigot/` instead of `/classes/` lol, but I've fixed that now.