### PR TITLE
Preload ProtocolLib EnumWrappers

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -289,6 +289,7 @@ This is an overview over all patches that are currently used.
 | server |  Players should not cram to death      | William Blake Galbreath |  |
 | server |  Populator seed controls      | Spottedleaf |  |
 | server |  Port hydrogen      | JellySquid |  |
+| server |  Preload ProtocolLib EnumWrappers      | ishland |  |
 | server |  Prevent light queue overfill when no players are online      | Spottedleaf |  |
 | server |  Prevent long map entry creation in light engine      | Spottedleaf |  |
 | server |  Prevent unload() calls removing tickets for sync loads      | Spottedleaf |  |

--- a/patches/server/0061-Preload-ProtocolLib-EnumWrappers.patch
+++ b/patches/server/0061-Preload-ProtocolLib-EnumWrappers.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ishland <ishlandmc@yeah.net>
+Date: Wed, 27 Jan 2021 20:16:47 +0800
+Subject: [PATCH] Preload ProtocolLib EnumWrappers
+
+Currently, ProtocolLib load EnumWrappers lazily and causing memory effects issues. This patch preloads EnumWrappers to prevent further NPE.
+
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 87cf9cd88d1fb5ae70d19e5618ebfb67d281304a..2a06f663ce64529842cfb0f4cf16c28ee143f110 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -959,6 +959,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+                 // Paper end
+ 
+                 PaperJvmChecker.checkJvm(); // Paper jvm version nag
++                if (org.yatopiamc.yatopia.server.YatopiaConfig.fixProtocolLib) org.yatopiamc.yatopia.server.util.YatopiaPreloadProtocolLib.run(); // Yatopia
+                 com.tuinity.tuinity.config.TuinityConfig.createWorldSections = false; // Tuinity - don't let plugin created worlds fill our config
+                 org.spigotmc.WatchdogThread.tick(); // Paper
+                 org.spigotmc.WatchdogThread.hasStarted = true; // Paper
+diff --git a/src/main/java/org/yatopiamc/yatopia/server/YatopiaConfig.java b/src/main/java/org/yatopiamc/yatopia/server/YatopiaConfig.java
+index c2dc5265552ebd429111253c70481003a4be29dd..15e2fa125bc293b954cceb5b1fbcec7fade3e4db 100644
+--- a/src/main/java/org/yatopiamc/yatopia/server/YatopiaConfig.java
++++ b/src/main/java/org/yatopiamc/yatopia/server/YatopiaConfig.java
+@@ -271,4 +271,9 @@ public class YatopiaConfig {
+         logPlayerLoginLoc = getBoolean("settings.log-player-login-location", logPlayerLoginLoc);
+     }
+ 
++    public static boolean fixProtocolLib = true;
++    private static void protocolLib() {
++        fixProtocolLib = getBoolean("settings.fix-protocollib", fixProtocolLib);
++    }
++
+ }
+diff --git a/src/main/java/org/yatopiamc/yatopia/server/util/YatopiaPreloadProtocolLib.java b/src/main/java/org/yatopiamc/yatopia/server/util/YatopiaPreloadProtocolLib.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..85906aa00163a4626b16190e2e48385bc5eba801
+--- /dev/null
++++ b/src/main/java/org/yatopiamc/yatopia/server/util/YatopiaPreloadProtocolLib.java
+@@ -0,0 +1,28 @@
++package org.yatopiamc.yatopia.server.util;
++
++import net.minecraft.server.MinecraftServer;
++import org.bukkit.Bukkit;
++import org.bukkit.plugin.Plugin;
++import org.bukkit.plugin.SimplePluginManager;
++
++import java.lang.reflect.Method;
++
++public class YatopiaPreloadProtocolLib {
++
++    public synchronized static void run() {
++        try {
++            final SimplePluginManager pluginManager = (SimplePluginManager) Bukkit.getPluginManager();
++            final Plugin protocolLib = pluginManager.getPlugin("ProtocolLib");
++            if(protocolLib != null && protocolLib.isEnabled()) {
++                MinecraftServer.LOGGER.info("Yatopia: Attempting to fix ProtocolLib");
++                final Method initialize = Class.forName("com.comphenix.protocol.wrappers.EnumWrappers", true, protocolLib.getClass().getClassLoader()).getDeclaredMethod("initialize");
++                initialize.setAccessible(true);
++                initialize.invoke(null);
++                synchronized (YatopiaPreloadProtocolLib.class) {
++                }
++            }
++        } catch (Throwable t) {
++            MinecraftServer.LOGGER.warn("Unable to fix ProtocolLib", t);
++        }
++    }
++}


### PR DESCRIPTION
Currently, ProtocolLib load EnumWrappers lazily and causing memory effects issues. This patch preloads EnumWrappers to prevent further NPE.

Fixed error log: 
![image](https://user-images.githubusercontent.com/30385023/105990877-0f433100-60de-11eb-827f-77146b1188af.png)
