### PR TITLE
Fixed netty timeout exception warn in the console

### DIFF
--- a/patches/server/0001-Modify-POM.patch
+++ b/patches/server/0001-Modify-POM.patch
@@ -59,7 +59,7 @@ index 752d62eb3b87ab24260ec2c029bae0d2b0e3b908..e790d779d24c2c8d4a74d458839c11bc
              <groupId>io.netty</groupId>
              <artifactId>netty-all</artifactId>
 -            <version>4.1.50.Final</version>
-+            <version>4.1.58.Final</version>
++            <version>4.1.59.Final</version>
          </dependency>
          <!-- Tuinity end - fix compile issue (cannot see new api) by moving netty include BEFORE server jar -->
          <dependency>


### PR DESCRIPTION
From my testing , This issue appeared after yatopia updated netty to 4.1.58 . 

Updating netty to latest stable release (4.1.59) , fixed these issues for me.

It's not high priority because it only spams sometimes in the console, when no player is online , but nothing serious, but it might have frustrated some people.
