### PR TITLE
Updated Upstream and Sidestream(s) (Paper)

### DIFF
--- a/patches/Purpur/patches/api/0031-Fix-javadoc-warnings-missing-param-and-return.patch
+++ b/patches/Purpur/patches/api/0031-Fix-javadoc-warnings-missing-param-and-return.patch
@@ -380,10 +380,10 @@ index 9db0056ab94145819628b3ad8d8d26130d117fcf..680410d8404a6d3b0ac91aa5fc4cd9d7
  
      public static void sneaky(@NotNull Throwable exception) {
 diff --git a/src/main/java/com/destroystokyo/paper/util/VersionFetcher.java b/src/main/java/com/destroystokyo/paper/util/VersionFetcher.java
-index 2a2651299e8dc631938ba4b4078dc694764d784c..62fafc206e7f1d8fdc0b0dfa2c1c6f1d280f4f5e 100644
+index a736d7bcdc5861a01b66ba36158db1c716339346..4825c9ca2191d3bf1440b986827fc32e230a3280 100644
 --- a/src/main/java/com/destroystokyo/paper/util/VersionFetcher.java
 +++ b/src/main/java/com/destroystokyo/paper/util/VersionFetcher.java
-@@ -3,6 +3,9 @@ package com.destroystokyo.paper.util;
+@@ -5,6 +5,9 @@ import net.kyori.adventure.text.format.NamedTextColor;
  import org.bukkit.Bukkit;
  import org.jetbrains.annotations.NotNull;
  
@@ -393,9 +393,9 @@ index 2a2651299e8dc631938ba4b4078dc694764d784c..62fafc206e7f1d8fdc0b0dfa2c1c6f1d
  public interface VersionFetcher {
      /**
       * Amount of time to cache results for in milliseconds
-@@ -25,6 +28,9 @@ public interface VersionFetcher {
+@@ -26,6 +29,9 @@ public interface VersionFetcher {
      @NotNull
-     String getVersionMessage(@NotNull String serverVersion);
+     Component getVersionMessage(@NotNull String serverVersion);
  
 +    /**
 +     * Dummy version fetcher

--- a/patches/Tuinity/patches/server/0012-Update-version-fetcher-repo.patch
+++ b/patches/Tuinity/patches/server/0012-Update-version-fetcher-repo.patch
@@ -6,23 +6,23 @@ Subject: [PATCH] Update version fetcher repo
 Sets the target github repo to Tuinity in the version checker. Also disables the jenkins build lookups.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-index 49a38c6608b652ff48ef4eaca0dd3ccb1ba570e3..255bbd6e48b95c70fad02ba692c64c7579496827 100644
+index dc0ea65ab87255fad0d54dfb509300098a0b4864..7063f1da3654b382e26b0093ad5d0ff04a2b38c2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-@@ -24,8 +24,8 @@ public class PaperVersionFetcher implements VersionFetcher {
+@@ -28,8 +28,8 @@ public class PaperVersionFetcher implements VersionFetcher {
      @Nonnull
      @Override
-     public String getVersionMessage(@Nonnull String serverVersion) {
+     public Component getVersionMessage(@Nonnull String serverVersion) {
 -        String[] parts = serverVersion.substring("git-Paper-".length()).split("[-\\s]");
--        String updateMessage = getUpdateStatusMessage("PaperMC/Paper", GITHUB_BRANCH_NAME, parts[0]);
+-        final Component updateMessage = getUpdateStatusMessage("PaperMC/Paper", GITHUB_BRANCH_NAME, parts[0]);
 +        String[] parts = serverVersion.substring("git-Tuinity-".length()).split("[-\\s]"); // Tuinity
-+        String updateMessage = getUpdateStatusMessage("Spottedleaf/Tuinity", GITHUB_BRANCH_NAME, parts[0]); // Tuinity
-         String history = getHistory();
++        final Component updateMessage = getUpdateStatusMessage("Spottedleaf/Tuinity", GITHUB_BRANCH_NAME, parts[0]); // Tuinity
+         final Component history = getHistory();
  
-         return history != null ? history + "\n" + updateMessage : updateMessage;
-@@ -49,13 +49,10 @@ public class PaperVersionFetcher implements VersionFetcher {
+         return history != null ? TextComponent.ofChildren(updateMessage, Component.newline(), history) : updateMessage;
+@@ -53,13 +53,10 @@ public class PaperVersionFetcher implements VersionFetcher {
  
-     private static String getUpdateStatusMessage(@Nonnull String repo, @Nonnull String branch, @Nonnull String versionInfo) {
+     private static Component getUpdateStatusMessage(@Nonnull String repo, @Nonnull String branch, @Nonnull String versionInfo) {
          int distance;
 -        try {
 -            int jenkinsBuild = Integer.parseInt(versionInfo);


### PR DESCRIPTION
Upstream/An Sidestream has released updates that appears to apply and compile correctly
This update has NOT been tested by YatopiaMC and as with ANY update, please do your own testing.

Paper Changes:
e849c51da fix #5336
0b25bacfc fix patch 'Remove streams from SensorNearest' (fixes #5330)
4d287e31c Use Adventure for `/version` command feedback, add copy to clipboard click event (#5333)