### PR TITLE
Use master branch in patch dirs

### DIFF
--- a/buildSrc/src/main/kotlin/task/ApplyPatches.kt
+++ b/buildSrc/src/main/kotlin/task/ApplyPatches.kt
@@ -87,8 +87,10 @@ internal fun Project.createApplyPatchesTask(
 
                 if (applyPatches(patchDir, upstream.name, name, wasGitSigningEnabled, projectDir)) continue
             }
-            project.gitCmd("branch", "-D", "$forkName-$folder", dir = projectDir)
-            project.gitCmd("checkout", "-b", "$forkName-$folder", dir = projectDir)
+            // project.gitCmd("branch", "-D", "$forkName-$folder", dir = projectDir)
+            // project.gitCmd("checkout", "-b", "$forkName-$folder", dir = projectDir)
+            project.gitCmd("branch", "-D", "master", dir = projectDir)
+            project.gitCmd("checkout", "-b", "master", dir = projectDir)
             val patchDir = patchesDir.toPath()
             // Apply patches
             if (applyPatches(patchDir, forkName, name, wasGitSigningEnabled, projectDir)) continue

--- a/buildSrc/src/main/kotlin/task/FixBranches.kt
+++ b/buildSrc/src/main/kotlin/task/FixBranches.kt
@@ -46,7 +46,8 @@ internal fun Project.createFixBranchesTask(
                     ensureSuccess(gitCmd("reset", "--hard", nameMap.get(branchName) as String, dir = subprojectWorkDir,
                         printOut = true))
             }
-            ensureSuccess(gitCmd("checkout", "${toothpick.forkName}-$folder", dir = subprojectWorkDir,
+            // ensureSuccess(gitCmd("checkout", "${toothpick.forkName}-$folder", dir = subprojectWorkDir,
+            ensureSuccess(gitCmd("checkout", "master", dir = subprojectWorkDir,
                 printOut = true))
         }
     }

--- a/buildSrc/src/main/kotlin/task/FixBranches.kt
+++ b/buildSrc/src/main/kotlin/task/FixBranches.kt
@@ -19,7 +19,8 @@ internal fun Project.createFixBranchesTask(
     doLast {
         for (folder in folderArray) {
             val subprojectWorkDir = Paths.get("${toothpick.forkName}-${if (folder == "api") {"API"} else {"Server"}}").toFile()
-            val currentBranchCommits = gitCmd("--no-pager", "log", "${toothpick.forkName}-$folder...${toothpick.upstreamBranch}", "--pretty=oneline",
+            // val currentBranchCommits = gitCmd("--no-pager", "log", "${toothpick.forkName}-$folder...${toothpick.upstreamBranch}", "--pretty=oneline",
+            val currentBranchCommits = gitCmd("--no-pager", "log", "master...${toothpick.upstreamBranch}", "--pretty=oneline",
                 dir = subprojectWorkDir).output.toString()
             val nameMap = ConcurrentHashMap<String, String>()
             for (upstream in upstreams) {

--- a/buildSrc/src/main/kotlin/task/RebuildPatches.kt
+++ b/buildSrc/src/main/kotlin/task/RebuildPatches.kt
@@ -60,10 +60,17 @@ private fun Project.updatePatches(
         ?.forEach { it -> it.delete() }
 
     ensureSuccess(
-        gitCmd(
-            "checkout", "$name-$folder", dir = projectDir,
-            printOut = true
-        )
+        if (name != "Yatopia") {
+            gitCmd(
+                "checkout", "$name-$folder", dir = projectDir,
+                printOut = true
+            )
+        } else {
+            gitCmd(
+                "checkout", "master", dir = projectDir,
+                printOut = true
+            )
+        }
     )
     ensureSuccess(
         gitCmd(

--- a/buildSrc/src/main/kotlin/task/RebuildPatches.kt
+++ b/buildSrc/src/main/kotlin/task/RebuildPatches.kt
@@ -32,7 +32,8 @@ internal fun Project.createRebuildPatchesTask(
                 updatePatches(patchPath, upstream.name, folder, projectDir, previousUpstreamName)
                 previousUpstreamName = "${upstream.name}-$folder"
             }
-            ensureSuccess(gitCmd("checkout", "$forkName-$folder", dir = projectDir,
+            // ensureSuccess(gitCmd("checkout", "$forkName-$folder", dir = projectDir,
+            ensureSuccess(gitCmd("checkout", "master", dir = projectDir,
                 printOut = true))
 
             updatePatches(patchesDir, toothpick.forkName, folder, projectDir, previousUpstreamName)


### PR DESCRIPTION
This PR aims to use `master` as a branch name instead of `Yatopia-api` or `Yatopia-server` in `Yatopia-API` and `Yatopia-Server` respectivly. I think I got it working properly, but someone should look it over before merging.