### PR TITLE
fix typo in Upstream.kt

### DIFF
--- a/buildSrc/src/main/kotlin/Upstream.kt
+++ b/buildSrc/src/main/kotlin/Upstream.kt
@@ -15,7 +15,7 @@ open class Upstream(in_name: String, in_useBlackList: Boolean, in_list: String, 
 
     var serverList = list.stream().filter { patch -> patch.startsWith("server/") }
         ?.sorted()?.map { patch -> patch.substring(7, patch.length) }?.collect(Collectors.toList())
-    var apiList = list.stream().filter { patch -> patch.startsWith("API/") }
+    var apiList = list.stream().filter { patch -> patch.startsWith("api/") }
         ?.sorted()?.map { patch -> patch.substring(4, patch.length) }?.collect(Collectors.toList())
 
 

--- a/upstreamConfig/0005-Empirecraft.properties
+++ b/upstreamConfig/0005-Empirecraft.properties
@@ -1,4 +1,4 @@
 name=Empirecraft
 useBlackList=false
-list=API/Add-ChatColor.getById.patch,server/Don-t-trigger-Lootable-Refresh-for-non-player-intera.patch,server/Fix-Bukkit.createInventory-with-type-LECTERN.patch,server/dont-load-chunks-for-physics.patch
+list=api/Add-ChatColor.getById.patch,server/Don-t-trigger-Lootable-Refresh-for-non-player-intera.patch,server/Fix-Bukkit.createInventory-with-type-LECTERN.patch,server/dont-load-chunks-for-physics.patch
 branch=origin/master


### PR DESCRIPTION
0003-Purpur.properties:
```
list=api/Tuinity-API-Changes.patch,api/Airplane-API-Changes.patch,server/Tuinity-Server-C
```
Upstream.kt:
```
 var apiList = list.stream().filter { patch -> patch.startsWith("API/") }
```

One must be typo