### PR TITLE
Move to setup-java v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'adopt'
         java-version: ${{ matrix.java }}
         
     - name: Pull Gradle Cache


### PR DESCRIPTION
Hello again guys! 😊  Love all the hard work recently 

This pr moves to the new v2 of setup java. It is a breaking change and requires the distribiution field, I didn't add ci-skip so you could see that it works still 😇

I was thinking maybe we could also change the java 15 matrix build to java 16 now that its fully out !!

Tell me what you think 🤨

Ciao 