### PR TITLE
Allow "[CI-SKIP]" to be case-insensitive

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
                 jdk "OpenJDK 8"
             }
             steps {
-                scmSkip(deleteBuild: true, skipPattern:'.*\\[CI-SKIP\\].*')
+                scmSkip(deleteBuild: true, skipPattern:'.*\\[ci-skip\\].*')
                 sh 'git config --global gc.auto 0'
                 sh 'rm -rf ./target'
                 sh 'rm -rf ./Paper/Paper-API ./Paper/Paper-Server'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
                 jdk "OpenJDK 8"
             }
             steps {
-                scmSkip(deleteBuild: true, skipPattern:'.*\\[ci-skip\\].*')
+                scmSkip(deleteBuild: true, skipPattern:'.*\\[(ci-skip|CI-SKIP)\\].*')
                 sh 'git config --global gc.auto 0'
                 sh 'rm -rf ./target'
                 sh 'rm -rf ./Paper/Paper-API ./Paper/Paper-Server'


### PR DESCRIPTION
should fix issues with [ci-skip] because it needed to be uppercase but wasn’t most of the time in commit messages